### PR TITLE
Singularize title in list.html

### DIFF
--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -2,7 +2,7 @@
     {{ $paginator := .Paginate .Data.Pages }}
     
     <main class="posts">
-        <h1>{{ .Title }}</h1>
+        <h1>{{ singularize .Title }}</h1>
 
         {{ if .Content }}
             <div class="content">{{ .Content }}</div>


### PR DESCRIPTION
I didn't want `Music` to transform to `Musics`. Not exactly sure where the pluralization occurs. So just convert back to singular before displaying